### PR TITLE
Add docker build windows support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM eclipse-temurin:17-jdk-alpine as build
 COPY . /home
 RUN cd /home && \
+    sed -i 's/\r$//' mvnw && \
     ./mvnw clean package
 
 # production environment


### PR DESCRIPTION
-Strips carriage returns from the mvnw file.
When building with code on a windows machine, the mvnw file needs to be stripped of carriage returns (\r) or else running docker build fails when locally creating an image.